### PR TITLE
Potential fix for code scanning alert no. 32: Unused import

### DIFF
--- a/src/cronk/cron_to_json.py
+++ b/src/cronk/cron_to_json.py
@@ -1,7 +1,7 @@
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
+from typing import List, Tuple
 
 from loguru import logger
 


### PR DESCRIPTION
Potential fix for [https://github.com/FelipeAnibal/cronk-aula/security/code-scanning/32](https://github.com/FelipeAnibal/cronk-aula/security/code-scanning/32)

To fix the problem, we need to remove the unused import statement for `Dict` from the `typing` module. This will clean up the code and remove the unnecessary dependency. The best way to fix this is to edit the import statement on line 4 to only include the types that are actually used (`List` and `Tuple`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
