### PR TITLE
Potential fix for code scanning alert no. 31: Unused import

### DIFF
--- a/src/cronk/cron_to_json.py
+++ b/src/cronk/cron_to_json.py
@@ -1,6 +1,6 @@
 import json
 import re
-from dataclasses import dataclass, field
+
 from typing import Dict, List, Tuple
 
 from loguru import logger


### PR DESCRIPTION
Potential fix for [https://github.com/FelipeAnibal/cronk-aula/security/code-scanning/31](https://github.com/FelipeAnibal/cronk-aula/security/code-scanning/31)

To fix the problem, we need to remove the unused imports from the `dataclasses` module. This will clean up the code and remove unnecessary dependencies, making the code easier to read and maintain.

- Identify the unused imports in the file.
- Remove the import statement for `dataclass` and `field` from the `dataclasses` module.
- Ensure that no other parts of the code rely on these imports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
